### PR TITLE
feat: Add switch and select entities for pump control

### DIFF
--- a/custom_components/pentair_cloud/__init__.py
+++ b/custom_components/pentair_cloud/__init__.py
@@ -17,7 +17,7 @@ from .entity import PentairDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/pentair_cloud/coordinator.py
+++ b/custom_components/pentair_cloud/coordinator.py
@@ -52,19 +52,68 @@ class PentairDataUpdateCoordinator(DataUpdateCoordinator):
             if device_type is None or device["deviceType"] == device_type
         ]
 
+    def _normalize_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
+        """Normalize field data from detailed API response.
+
+        The get_device API returns full field objects like:
+          {"s17": {"name": "...", "value": "436", ...}}
+        But existing pypentair code and sensors expect just:
+          {"s17": "436"}
+        """
+        normalized = {}
+        for key, value in fields.items():
+            if isinstance(value, dict) and "value" in value:
+                # Extract just the value string for pypentair compatibility
+                normalized[key] = value["value"]
+            else:
+                # Keep as-is if not a dict or no "value" key
+                normalized[key] = value
+        return normalized
+
     async def _async_update_data(self):
         """Update data via library, refresh token if necessary."""
         try:
-            if devices := await self.hass.async_add_executor_job(self.api.get_devices):
-                diff = DeepDiff(
-                    self.devices,
-                    devices,
-                    ignore_order=True,
-                    report_repetition=True,
-                    verbose_level=2,
-                )
-                _LOGGER.debug("Devices updated: %s", diff if diff else "no changes")
-                self.devices = devices
+            # Get list of devices
+            devices_response = await self.hass.async_add_executor_job(self.api.get_devices)
+            if not devices_response:
+                return self.devices
+
+            # Fetch detailed data for each device (includes fields with program info)
+            detailed_devices = []
+            for device in devices_response.get("data", []):
+                device_id = device.get("deviceId")
+                if device_id:
+                    try:
+                        detailed = await self.hass.async_add_executor_job(
+                            self.api.get_device, device_id
+                        )
+                        if detailed and "data" in detailed:
+                            device_data = detailed["data"]
+                            # Normalize the fields to match expected format
+                            if "fields" in device_data:
+                                device_data["fields"] = self._normalize_fields(
+                                    device_data["fields"]
+                                )
+                            # Merge detailed data INTO original device to preserve
+                            # fields like lastReport that only exist in get_devices()
+                            merged_device = {**device, **device_data}
+                            detailed_devices.append(merged_device)
+                        else:
+                            detailed_devices.append(device)
+                    except Exception:  # pylint: disable=broad-except
+                        _LOGGER.warning("Failed to get detailed data for %s", device_id)
+                        detailed_devices.append(device)
+
+            devices = {"data": detailed_devices, "msgs": devices_response.get("msgs", [])}
+            diff = DeepDiff(
+                self.devices,
+                devices,
+                ignore_order=True,
+                report_repetition=True,
+                verbose_level=2,
+            )
+            _LOGGER.debug("Devices updated: %s", diff if diff else "no changes")
+            self.devices = devices
         except Exception as err:  # pylint: disable=broad-except
             _LOGGER.error(
                 "Unknown exception while updating Pentair data: %s", err, exc_info=1

--- a/custom_components/pentair_cloud/select.py
+++ b/custom_components/pentair_cloud/select.py
@@ -1,0 +1,149 @@
+"""Support for Pentair select (pump program selection)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import PentairDataUpdateCoordinator, PentairEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+OPTION_OFF = "Off"
+
+
+@dataclass
+class PentairSelectEntityDescription(SelectEntityDescription):
+    """Pentair select entity description."""
+
+    programs: dict[str, int] = field(default_factory=dict)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Pentair select using config entry."""
+    coordinator: PentairDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[PentairProgramSelectEntity] = []
+
+    # Create select entities for IF31 pumps
+    for device in coordinator.get_devices("IF31"):
+        device_id = device["deviceId"]
+        fields = device.get("fields", {})
+
+        # Build list of active programs (1-14)
+        programs: dict[str, int] = {}
+        for program_id in range(1, 15):
+            # Check if program is active (zp{N}e13 == "1")
+            # Fields are normalized to simple values: {"zp1e13": "1"}
+            active_value = fields.get(f"zp{program_id}e13")
+            if active_value != "1":
+                continue
+
+            # Get program name
+            program_name = fields.get(f"zp{program_id}e2", f"Program {program_id}")
+            programs[program_name] = program_id
+
+        if not programs:
+            continue
+
+        # Build options list with "Off" as first option
+        options = [OPTION_OFF] + list(programs.keys())
+
+        description = PentairSelectEntityDescription(
+            key="running_program",
+            name="Running program",
+            options=options,
+            programs=programs,
+        )
+
+        entities.append(
+            PentairProgramSelectEntity(
+                coordinator=coordinator,
+                config_entry=config_entry,
+                description=description,
+                device_id=device_id,
+            )
+        )
+
+    if not entities:
+        return
+
+    async_add_entities(entities)
+
+
+class PentairProgramSelectEntity(PentairEntity, SelectEntity):
+    """Pentair pump program select entity."""
+
+    entity_description: PentairSelectEntityDescription
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently selected program."""
+        device = self.get_device()
+        if device is None:
+            return None
+
+        fields = device.get("fields", {})
+        # s14 contains the currently running program (0-indexed, 99 = none)
+        # Fields are normalized to simple values: {"s14": "0"}
+        running_value = fields.get("s14", "99")
+        try:
+            running_program = int(running_value)
+        except (ValueError, TypeError):
+            return OPTION_OFF
+
+        if running_program >= 99:
+            return OPTION_OFF
+
+        # s14 is 0-indexed, so add 1 to get program_id
+        running_id = running_program + 1
+
+        # Find the program name for this ID
+        for name, prog_id in self.entity_description.programs.items():
+            if prog_id == running_id:
+                return name
+
+        return OPTION_OFF
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        if option == OPTION_OFF:
+            # Stop the currently running program
+            device = self.get_device()
+            if device:
+                fields = device.get("fields", {})
+                # Fields are normalized to simple values: {"s14": "0"}
+                running_value = fields.get("s14", "99")
+                try:
+                    running_program = int(running_value)
+                    if running_program < 99:
+                        # Stop the running program
+                        await self.hass.async_add_executor_job(
+                            self.coordinator.api.stop_program,
+                            self._device_id,
+                            running_program + 1,
+                        )
+                except (ValueError, TypeError):
+                    pass
+        else:
+            # Start the selected program
+            program_id = self.entity_description.programs.get(option)
+            if program_id:
+                await self.hass.async_add_executor_job(
+                    self.coordinator.api.start_program,
+                    self._device_id,
+                    program_id,
+                )
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/pentair_cloud/sensor.py
+++ b/custom_components/pentair_cloud/sensor.py
@@ -51,7 +51,7 @@ SENSOR_MAP: dict[str | None, tuple[PentairSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.TIMESTAMP,
             entity_category=EntityCategory.DIAGNOSTIC,
             translation_key="last_report",
-            value_fn=lambda data: convert_timestamp(data["lastReport"]),
+            value_fn=lambda data: convert_timestamp(data.get("lastReport")) if data and data.get("lastReport") else None,
         ),
     ),
     "IF31": (

--- a/custom_components/pentair_cloud/strings.json
+++ b/custom_components/pentair_cloud/strings.json
@@ -36,6 +36,16 @@
       "secondary_pump": { "name": "Secondary pump" },
       "water_level": { "name": "Water level" }
     },
+    "number": {
+      "program_gpm": { "name": "GPM" },
+      "program_speed": { "name": "Speed" }
+    },
+    "select": {
+      "running_program": { "name": "Running program" }
+    },
+    "switch": {
+      "pump_enabled": { "name": "Pump enabled" }
+    },
     "sensor": {
       "average_salt_usage_per_day": { "name": "Average daily salt usage" },
       "battery_level": { "name": "Battery level" },

--- a/custom_components/pentair_cloud/switch.py
+++ b/custom_components/pentair_cloud/switch.py
@@ -1,0 +1,201 @@
+"""Support for Pentair switches (pump control)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import PentairDataUpdateCoordinator, PentairEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PentairProgramSwitchEntityDescription(SwitchEntityDescription):
+    """Pentair program switch entity description."""
+
+    program_id: int = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Pentair switches using config entry."""
+    coordinator: PentairDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities: list[SwitchEntity] = []
+
+    # Create switch entities for IF31 pumps
+    for device in coordinator.get_devices("IF31"):
+        device_id = device["deviceId"]
+        fields = device.get("fields", {})
+
+        # Add pump enable switch
+        entities.append(
+            PentairPumpEnableSwitchEntity(
+                coordinator=coordinator,
+                config_entry=config_entry,
+                description=SwitchEntityDescription(
+                    key="pump_enabled",
+                    name="Pump enabled",
+                    icon="mdi:pump",
+                ),
+                device_id=device_id,
+            )
+        )
+
+        # Add program switches for active programs (1-14)
+        for program_id in range(1, 15):
+            # Check if program is active (zp{N}e13 == "1")
+            # Fields are normalized to simple values: {"zp1e13": "1"}
+            active_value = fields.get(f"zp{program_id}e13")
+            if active_value != "1":
+                continue
+
+            # Get program name
+            program_name = fields.get(f"zp{program_id}e2", f"Program {program_id}")
+
+            description = PentairProgramSwitchEntityDescription(
+                key=f"program_{program_id}",
+                name=program_name,
+                program_id=program_id,
+            )
+
+            entities.append(
+                PentairProgramSwitchEntity(
+                    coordinator=coordinator,
+                    config_entry=config_entry,
+                    description=description,
+                    device_id=device_id,
+                )
+            )
+
+    if not entities:
+        return
+
+    async_add_entities(entities)
+
+
+class PentairPumpEnableSwitchEntity(PentairEntity, SwitchEntity):
+    """Pentair pump enable switch entity."""
+
+    _optimistic_state: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the pump is enabled."""
+        # Use optimistic state if set (command was just sent)
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+
+        device = self.get_device()
+        if device is None:
+            return None
+
+        fields = device.get("fields", {})
+        # d25 contains pump enabled status (1 = enabled)
+        # Fields are normalized to simple values: {"d25": "1"}
+        enabled_value = fields.get("d25")
+        if enabled_value is None:
+            return None
+        return enabled_value == "1"
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        # Clear optimistic state when we get real data
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the pump."""
+        self._optimistic_state = True
+        self.async_write_ha_state()
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_pump_enabled,
+            self._device_id,
+            True,
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the pump."""
+        self._optimistic_state = False
+        self.async_write_ha_state()
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_pump_enabled,
+            self._device_id,
+            False,
+        )
+
+
+class PentairProgramSwitchEntity(PentairEntity, SwitchEntity):
+    """Pentair pump program switch entity."""
+
+    entity_description: PentairProgramSwitchEntityDescription
+    _optimistic_state: bool | None = None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the program is running."""
+        # Use optimistic state if set (command was just sent)
+        if self._optimistic_state is not None:
+            return self._optimistic_state
+
+        device = self.get_device()
+        if device is None:
+            return None
+
+        fields = device.get("fields", {})
+        # s14 contains the currently running program (0-indexed, 99 = none)
+        # Fields are normalized to simple values: {"s14": "0"}
+        running_value = fields.get("s14", "99")
+        try:
+            running_program = int(running_value)
+        except (ValueError, TypeError):
+            return None
+
+        # s14 is 0-indexed, so program 1 = s14 value 0
+        return running_program + 1 == self.entity_description.program_id
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        # Clear optimistic state when we get real data
+        self._optimistic_state = None
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the program (start it)."""
+        # Set optimistic state immediately for responsive UI
+        self._optimistic_state = True
+        self.async_write_ha_state()
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.start_program,
+            self._device_id,
+            self.entity_description.program_id,
+        )
+        # Don't refresh immediately - pump needs time to update cloud state
+        # The 30-second coordinator interval will pick up the confirmed state
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the program (stop it)."""
+        # Set optimistic state immediately for responsive UI
+        self._optimistic_state = False
+        self.async_write_ha_state()
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.stop_program,
+            self._device_id,
+            self.entity_description.program_id,
+        )
+        # Don't refresh immediately - pump needs time to update cloud state


### PR DESCRIPTION
## Summary

This PR adds control capabilities to the hacs-pentair Home Assistant integration for IntelliFlo/IntelliPro pumps. Users can now:

- Turn pump programs on/off via switch entities
- Select which program to run via select entities
- Enable/disable the pump via a master switch

## New Platforms

| Platform | Entity Type | Purpose |
|----------|-------------|---------|
| `switch` | Switch | Program on/off, Pump enable |
| `select` | Select (dropdown) | Program selection |

## Entity Details

### Switch Entities

| Entity ID Pattern | Description |
|-------------------|-------------|
| `switch.{pump}_pump_enabled` | Master pump enable/disable |
| `switch.{pump}_{program_name}` | Start/stop specific program |

### Select Entities

| Entity ID Pattern | Description |
|-------------------|-------------|
| `select.{pump}_running_program` | Dropdown to select active program |

**Options:** "Off" + all configured program names

## Files Changed

### New Files

| File | Purpose |
|------|---------|
| `switch.py` | Switch platform for pump enable and program control |
| `select.py` | Select platform for program dropdown |

### Modified Files

| File | Changes |
|------|---------|
| `__init__.py` | Added `switch`, `select` to PLATFORMS list |
| `coordinator.py` | Fetch detailed device data, normalize fields, preserve lastReport |
| `sensor.py` | Fixed lastReport handling |
| `strings.json` | Add entity translations |

## Technical Details

### Coordinator Changes

**Problem:** The `get_devices()` API returns empty `fields` objects, but `get_device(device_id)` returns full field data including program information. However, `get_device()` doesn't include `lastReport`.

**Solution:** Modified `_async_update_data()` to:
1. Call `get_devices()` to get device list (includes `lastReport`)
2. For each device, call `get_device(device_id)` to get detailed data with fields
3. Normalize field data from `{"s17": {"value": "436"}}` to `{"s17": "436"}`
4. Merge detailed data INTO original device to preserve `lastReport`

### Optimistic State

Switch entities use optimistic state for responsive UI during cloud API latency. State immediately updates in the UI, then gets confirmed by the next coordinator refresh (30 seconds).

## Program Detection

Programs are detected using the `zp{N}e13` field:
- Value `"1"` = program is active/configured
- Programs 1-14 are scanned during entity setup

Program names come from `zp{N}e2` field.

## Dependencies

**Requires pypentair with control methods:**
- `start_program(device_id, program_id)`
- `stop_program(device_id, program_id)`
- `set_pump_enabled(device_id, enabled)`

See: https://github.com/natekspencer/pypentair/pull/90

## Testing

### Hardware Tested
- IntelliFlo/IntelliPro3 VSF Main Pump
- IntelliFlo/IntelliPro3 VSF Booster Pump

### Verified
- ✅ Program switches turn programs on/off
- ✅ Select dropdown changes running program
- ✅ Pump enable switch works
- ✅ Existing sensors continue working
- ✅ Last report sensor shows correct timestamp

## Breaking Changes

None. Existing sensor entities continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pump program selection control to choose active programs.
  * Added pump enable/disable switch for pump control.
  * Expanded Pentair Cloud integration with SELECT and SWITCH platform support.

* **Bug Fixes**
  * Improved null-safety for last_report sensor data retrieval.
  * Enhanced per-device data fetching with graceful error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->