### PR TITLE
Color Sync (PLC1) control entities: on/off + 12 scenes + Hold/Recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@
 
 Home Assistant integration for Pentair Home devices.
 
+## 🌊 Supported devices
+
+The integration auto-discovers every device on your Pentair Home account and exposes the underlying telemetry as `sensor` / `binary_sensor` entities for diagnostics.  On top of that, the device types below get first-class **control** entities:
+
+### Color Sync (`deviceType: PLC1`, e.g. part **618031** — MicroBrite RGB pool lights)
+
+| Entity | Type | What it does | Backing field |
+|---|---|---|---|
+| Pool lights | `switch` | On / off | `d13` (0/1) |
+| Pool lights mode | `select` | One of 12 scenes: Red, White, Magenta, Green, Blue, SAm, Party, Romance, Caribbean, American, Sunset, Royal | `d1` (0..4, 7..13) |
+| Pool lights hold | `button` | Freezes the current animation on its present color | `d1` = 5 |
+| Pool lights recall | `button` | Resumes the last show that was running before Hold | `d1` = 6 |
+
+> The Color Sync controller is a cloud-only product (no LAN API).  Control happens via Pentair's REST endpoint, signed with the AWS Cognito tokens this integration already maintains.
+
+### IntelliFlo / IntelliCenter and other Pentair devices
+
+Read-only telemetry today — `switch` / `select` / `button` platforms are scoped to PLC1, but the platform files use device-type lookup tables so adding more device families is just a matter of describing the right fields.
+
 <!-- BEGIN AUTO-GENERATED INSTALLATION -->
 
 ## ⬇️ Installation

--- a/custom_components/pentair_cloud/__init__.py
+++ b/custom_components/pentair_cloud/__init__.py
@@ -23,7 +23,13 @@ type PentairConfigEntry = ConfigEntry[PentairDataUpdateCoordinator]
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PentairConfigEntry) -> bool:

--- a/custom_components/pentair_cloud/button.py
+++ b/custom_components/pentair_cloud/button.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant

--- a/custom_components/pentair_cloud/button.py
+++ b/custom_components/pentair_cloud/button.py
@@ -1,0 +1,88 @@
+"""Pentair button platform.
+
+Buttons cover write-only command transitions that aren't steady states.
+For Color Sync that's Hold (`d1=5`, freezes the current animation on its
+present color) and Recall (`d1=6`, resumes the last show before Hold).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import PentairConfigEntry
+from .entity import PentairEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class PentairButtonEntityDescription(ButtonEntityDescription):
+    """Describes a write-only Pentair command button."""
+
+    field: str
+    value: str
+
+
+_COLOR_SYNC_BUTTONS: list[PentairButtonEntityDescription] = [
+    PentairButtonEntityDescription(
+        key="pool_lights_hold",
+        field="d1",
+        value="5",
+        translation_key="pool_lights_hold",
+        icon="mdi:pause",
+    ),
+    PentairButtonEntityDescription(
+        key="pool_lights_recall",
+        field="d1",
+        value="6",
+        translation_key="pool_lights_recall",
+        icon="mdi:play",
+    ),
+]
+
+_SUPPORTED_DEVICE_TYPES: dict[str, list[PentairButtonEntityDescription]] = {
+    "PLC1": _COLOR_SYNC_BUTTONS,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: PentairConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pentair command buttons for supported device types."""
+    coordinator = config_entry.runtime_data
+    entities: list[PentairFieldButton] = []
+    for device_coordinator in coordinator.device_coordinators:
+        data = device_coordinator.get_device_data()
+        if not data:
+            continue
+        for description in _SUPPORTED_DEVICE_TYPES.get(data.get("deviceType"), []):
+            entities.append(
+                PentairFieldButton(
+                    coordinator=device_coordinator,
+                    config_entry=config_entry,
+                    description=description,
+                    device_id=data["deviceId"],
+                )
+            )
+    if entities:
+        async_add_entities(entities)
+
+
+class PentairFieldButton(PentairEntity, ButtonEntity):
+    """Button that writes a fixed value to a Pentair field on press."""
+
+    entity_description: PentairButtonEntityDescription
+
+    async def async_press(self) -> None:
+        await self.coordinator.async_set_fields(
+            {self.entity_description.field: self.entity_description.value}
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/pentair_cloud/coordinator.py
+++ b/custom_components/pentair_cloud/coordinator.py
@@ -3,17 +3,30 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import json
 import logging
 from typing import Any
+from urllib.parse import urljoin
 
+from botocore.awsrequest import AWSRequest
 from deepdiff import DeepDiff
 from pypentair import Pentair
+import requests
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
+
+# Pentair Home write endpoint.  pypentair 0.4.1 exposes only read methods
+# (`get_device`, `get_devices`), so we issue PUTs directly using the same
+# SigV4-signed AWS Cognito auth the library already produces.  Body shape
+# is `{"payload": {"<field>": "<value>"}}`; all values are strings.  Mirrors
+# the pattern in thk-socal/hacs-pentair-switch's IntelliFlo 3 work.
+_PENTAIR_BASE_URL = "https://api.pentair.cloud/"
+_PENTAIR_DEVICE_PATH = "device/device-service/user/device/{device_id}"
+_PENTAIR_USER_AGENT = "aws-amplify/4.3.10 react-native"
 
 _LOGGER = logging.getLogger(__name__)
 UPDATE_INTERVAL = 30
@@ -104,6 +117,18 @@ class PentairDeviceDataUpdateCoordinator(DataUpdateCoordinator):
             return data
         return None
 
+    async def async_set_fields(self, fields: dict[str, str]) -> dict[str, Any]:
+        """Send a SigV4-signed PUT updating one or more device fields.
+
+        All field values must be strings (Pentair Home's contract — even
+        numeric fields).  Returns the parsed response body.  Raises
+        `RuntimeError` if Pentair doesn't reply with
+        `code == "set_device_success"`.
+        """
+        return await self.hass.async_add_executor_job(
+            _signed_put_sync, self.api, self.device_id, fields
+        )
+
     async def _async_update_data(self):
         """Update data via library, refresh token if necessary."""
         try:
@@ -128,3 +153,40 @@ class PentairDeviceDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(err) from err
         else:
             return None
+
+
+def _signed_put_sync(
+    client: Pentair, device_id: str, fields: dict[str, str]
+) -> dict[str, Any]:
+    """Blocking SigV4-signed PUT helper, called from `async_add_executor_job`.
+
+    Build an AWSRequest, let pypentair's existing `get_auth()` add the SigV4
+    signature, then `requests.request` with the signed headers.  Validate
+    that Pentair acknowledged with `set_device_success`.
+    """
+    url = urljoin(_PENTAIR_BASE_URL, _PENTAIR_DEVICE_PATH.format(device_id=device_id))
+    body = json.dumps({"payload": fields})
+    req = AWSRequest(
+        method="PUT",
+        url=url,
+        data=body,
+        headers={
+            "x-amz-id-token": client.id_token,
+            "content-type": "application/json; charset=UTF-8",
+            "user-agent": _PENTAIR_USER_AGENT,
+        },
+    )
+    client.get_auth().add_auth(req)
+    prepared = req.prepare()
+    response = requests.request(
+        method="PUT",
+        url=prepared.url,
+        data=body,
+        headers=dict(prepared.headers),
+        timeout=15,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("data", {}).get("code") != "set_device_success":
+        raise RuntimeError(f"Pentair API rejected write: {payload}")
+    return payload

--- a/custom_components/pentair_cloud/coordinator.py
+++ b/custom_components/pentair_cloud/coordinator.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 from datetime import timedelta
 import json
 import logging
+import time
 from typing import Any
 from urllib.parse import urljoin
 
@@ -28,8 +30,67 @@ _PENTAIR_BASE_URL = "https://api.pentair.cloud/"
 _PENTAIR_DEVICE_PATH = "device/device-service/user/device/{device_id}"
 _PENTAIR_USER_AGENT = "aws-amplify/4.3.10 react-native"
 
+# Pentair Cognito id_tokens are 60-min JWTs (ttl = exp - iat = 3600s).
+# We refresh proactively when fewer than this many seconds remain on the
+# cached id_token so we never *intentionally* issue a stale token.  The
+# 401/403-reactive refresh below is the safety net for mid-call expiry
+# or server-side revoke.
+_REFRESH_HORIZON_SEC = 5 * 60
+
 _LOGGER = logging.getLogger(__name__)
 UPDATE_INTERVAL = 30
+
+
+def _id_token_ttl(client: Pentair) -> int:
+    """Seconds remaining on the cached id_token; 0 if absent / unparseable."""
+    tok = getattr(client, "id_token", None)
+    if not tok:
+        return 0
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(tok.split(".")[1] + "=="))
+        return max(0, int(payload.get("exp", 0)) - int(time.time()))
+    except Exception:  # pylint: disable=broad-except
+        return 0
+
+
+def _force_token_refresh(client: Pentair) -> None:
+    """Renew Cognito tokens using the cached refresh_token.
+
+    pycognito's ``check_token()`` does not reliably detect a stale id_token
+    in long-running processes (symptom: repeated ``403 — The security
+    token included in the request is expired`` after ~1 hour of uptime).
+    Calling ``renew_access_token()`` directly bypasses the broken exp
+    check and unconditionally swaps in fresh tokens via the refresh_token.
+    """
+    try:
+        client.get_user().renew_access_token()
+        _LOGGER.debug(
+            "Pentair tokens renewed (new id_token ttl=%ds)", _id_token_ttl(client)
+        )
+    except Exception as err:  # pylint: disable=broad-except
+        _LOGGER.warning("Pentair renew_access_token failed: %s", err)
+        raise
+
+
+def _ensure_token_fresh(client: Pentair) -> None:
+    """Proactively refresh the id_token when within the refresh horizon."""
+    ttl = _id_token_ttl(client)
+    if ttl < _REFRESH_HORIZON_SEC:
+        _LOGGER.debug(
+            "Pentair id_token ttl=%ds < %ds — proactively renewing",
+            ttl,
+            _REFRESH_HORIZON_SEC,
+        )
+        _force_token_refresh(client)
+
+
+def _is_auth_error(err: BaseException) -> bool:
+    """Return True if *err* is a Pentair API auth failure (401 / 403)."""
+    return (
+        isinstance(err, requests.HTTPError)
+        and err.response is not None
+        and err.response.status_code in (401, 403)
+    )
 
 
 class PentairDataUpdateCoordinator(DataUpdateCoordinator):
@@ -73,7 +134,9 @@ class PentairDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Update data via library, refresh token if necessary."""
         try:
-            if devices := await self.hass.async_add_executor_job(self.api.get_devices):
+            if devices := await self.hass.async_add_executor_job(
+                _get_devices_with_refresh, self.api
+            ):
                 diff = DeepDiff(
                     self.devices,
                     devices,
@@ -133,7 +196,7 @@ class PentairDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library, refresh token if necessary."""
         try:
             if device := await self.hass.async_add_executor_job(
-                self.api.get_device, self.device_id
+                _get_device_with_refresh, self.api, self.device_id
             ):
                 diff = DeepDiff(
                     self.data,
@@ -155,15 +218,45 @@ class PentairDeviceDataUpdateCoordinator(DataUpdateCoordinator):
             return None
 
 
-def _signed_put_sync(
-    client: Pentair, device_id: str, fields: dict[str, str]
-) -> dict[str, Any]:
-    """Blocking SigV4-signed PUT helper, called from `async_add_executor_job`.
+def _get_devices_with_refresh(client: Pentair) -> dict[str, Any] | None:
+    """Blocking ``client.get_devices()`` with proactive + reactive refresh."""
+    _ensure_token_fresh(client)
+    try:
+        return client.get_devices()
+    except requests.HTTPError as err:
+        if not _is_auth_error(err):
+            raise
+        _LOGGER.info(
+            "Pentair get_devices got HTTP %d despite pre-flight check — refreshing and retrying",
+            err.response.status_code,
+        )
+        _force_token_refresh(client)
+        return client.get_devices()
 
-    Build an AWSRequest, let pypentair's existing `get_auth()` add the SigV4
-    signature, then `requests.request` with the signed headers.  Validate
-    that Pentair acknowledged with `set_device_success`.
-    """
+
+def _get_device_with_refresh(client: Pentair, device_id: str) -> dict[str, Any] | None:
+    """Blocking ``client.get_device(id)`` with proactive + reactive refresh."""
+    _ensure_token_fresh(client)
+    try:
+        return client.get_device(device_id)
+    except requests.HTTPError as err:
+        if not _is_auth_error(err):
+            raise
+        _LOGGER.info(
+            "Pentair get_device(%s) got HTTP %d despite pre-flight check — refreshing and retrying",
+            device_id,
+            err.response.status_code,
+        )
+        _force_token_refresh(client)
+        return client.get_device(device_id)
+
+
+def _do_signed_put(
+    client: Pentair, device_id: str, fields: dict[str, str]
+) -> requests.Response:
+    """Build, sign, and execute one SigV4 PUT.  Returns the raw response so
+    callers can decide how to react to non-2xx codes (e.g. retry on auth
+    errors)."""
     url = urljoin(_PENTAIR_BASE_URL, _PENTAIR_DEVICE_PATH.format(device_id=device_id))
     body = json.dumps({"payload": fields})
     req = AWSRequest(
@@ -178,13 +271,36 @@ def _signed_put_sync(
     )
     client.get_auth().add_auth(req)
     prepared = req.prepare()
-    response = requests.request(
+    return requests.request(
         method="PUT",
         url=prepared.url,
         data=body,
         headers=dict(prepared.headers),
         timeout=15,
     )
+
+
+def _signed_put_sync(
+    client: Pentair, device_id: str, fields: dict[str, str]
+) -> dict[str, Any]:
+    """Blocking SigV4-signed PUT helper, called from `async_add_executor_job`.
+
+    Build an AWSRequest, let pypentair's existing `get_auth()` add the SigV4
+    signature, then `requests.request` with the signed headers.  Pre-flight
+    refreshes the id_token when within `_REFRESH_HORIZON_SEC` of expiry; on
+    a 401/403 from the API it refreshes once more and retries the call
+    exactly once.  Validates that Pentair acknowledged with
+    `set_device_success`.
+    """
+    _ensure_token_fresh(client)
+    response = _do_signed_put(client, device_id, fields)
+    if response.status_code in (401, 403):
+        _LOGGER.info(
+            "Pentair PUT got HTTP %d despite pre-flight check — refreshing and retrying",
+            response.status_code,
+        )
+        _force_token_refresh(client)
+        response = _do_signed_put(client, device_id, fields)
     response.raise_for_status()
     payload = response.json()
     if payload.get("data", {}).get("code") != "set_device_success":

--- a/custom_components/pentair_cloud/select.py
+++ b/custom_components/pentair_cloud/select.py
@@ -8,8 +8,7 @@ button entities instead (see `button.py`).
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass
 import logging
 from typing import Any
 
@@ -101,7 +100,9 @@ class PentairFieldSelect(PentairEntity, SelectEntity):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._name_to_value = {v: k for k, v in self.entity_description.value_to_option.items()}
+        self._name_to_value = {
+            v: k for k, v in self.entity_description.value_to_option.items()
+        }
         self._attr_options = list(self.entity_description.value_to_option.values())
 
     @property

--- a/custom_components/pentair_cloud/select.py
+++ b/custom_components/pentair_cloud/select.py
@@ -1,0 +1,124 @@
+"""Pentair select platform.
+
+Color Sync's `d1` field is an enum (0-13) selecting one of 12 named scenes
+(5 solid colors + 7 shows).  Values 5 (Hold) and 6 (Recall) are skipped
+here — they're command-style transitions, not steady states, and surface as
+button entities instead (see `button.py`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field as dataclass_field
+import logging
+from typing import Any
+
+from homeassistant.components.select import (
+    SelectEntity,
+    SelectEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import PentairConfigEntry
+from .entity import PentairEntity
+from .helpers import get_field_value
+
+_LOGGER = logging.getLogger(__name__)
+
+# d1 -> display name.  Empirically mapped by setting each value and reading
+# the canonical name back from the Pentair Home iOS app (2026-05-18 / PLC1
+# fwVersion 1.0).  Writing 14 is silently clamped to 13 by the device so
+# don't expose it.
+COLOR_SYNC_MODES: dict[int, str] = {
+    0: "Red",
+    1: "White",
+    2: "Magenta",
+    3: "Green",
+    4: "Blue",
+    # 5 = Hold, 6 = Recall — exposed via button.py
+    7: "SAm",
+    8: "Party",
+    9: "Romance",
+    10: "Caribbean",
+    11: "American",
+    12: "Sunset",
+    13: "Royal",
+}
+_NAME_TO_VALUE = {v: k for k, v in COLOR_SYNC_MODES.items()}
+
+
+@dataclass(frozen=True, kw_only=True)
+class PentairSelectEntityDescription(SelectEntityDescription):
+    """Entity description that carries the field + value/option mapping."""
+
+    field: str
+    value_to_option: dict[int, str]
+
+
+_COLOR_SYNC_MODE = PentairSelectEntityDescription(
+    key="d1",
+    field="d1",
+    translation_key="pool_lights_mode",
+    icon="mdi:palette",
+    value_to_option=COLOR_SYNC_MODES,
+)
+
+_SUPPORTED_DEVICE_TYPES: dict[str, list[PentairSelectEntityDescription]] = {
+    "PLC1": [_COLOR_SYNC_MODE],
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: PentairConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pentair select entities for supported device types."""
+    coordinator = config_entry.runtime_data
+    entities: list[PentairFieldSelect] = []
+    for device_coordinator in coordinator.device_coordinators:
+        data = device_coordinator.get_device_data()
+        if not data:
+            continue
+        for description in _SUPPORTED_DEVICE_TYPES.get(data.get("deviceType"), []):
+            entities.append(
+                PentairFieldSelect(
+                    coordinator=device_coordinator,
+                    config_entry=config_entry,
+                    description=description,
+                    device_id=data["deviceId"],
+                )
+            )
+    if entities:
+        async_add_entities(entities)
+
+
+class PentairFieldSelect(PentairEntity, SelectEntity):
+    """Select backed by a single integer-coded Pentair field."""
+
+    entity_description: PentairSelectEntityDescription
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._name_to_value = {v: k for k, v in self.entity_description.value_to_option.items()}
+        self._attr_options = list(self.entity_description.value_to_option.values())
+
+    @property
+    def current_option(self) -> str | None:
+        """Map the live field value back to its display name."""
+        if (data := self.get_device()) is None:
+            return None
+        raw = get_field_value(self.entity_description.field, data)
+        try:
+            return self.entity_description.value_to_option.get(int(raw))
+        except (TypeError, ValueError):
+            return None
+
+    async def async_select_option(self, option: str) -> None:
+        if (value := self._name_to_value.get(option)) is None:
+            raise ValueError(f"unknown option for {self.entity_id}: {option!r}")
+        await self.coordinator.async_set_fields(
+            {self.entity_description.field: str(value)}
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/pentair_cloud/strings.json
+++ b/custom_components/pentair_cloud/strings.json
@@ -43,6 +43,16 @@
       "last_report": { "name": "Last report" },
       "motor_speed": { "name": "Motor speed" },
       "salt_level": { "name": "Salt level" }
+    },
+    "switch": {
+      "pool_lights": { "name": "Pool lights" }
+    },
+    "select": {
+      "pool_lights_mode": { "name": "Pool lights mode" }
+    },
+    "button": {
+      "pool_lights_hold": { "name": "Hold" },
+      "pool_lights_recall": { "name": "Recall" }
     }
   }
 }

--- a/custom_components/pentair_cloud/switch.py
+++ b/custom_components/pentair_cloud/switch.py
@@ -95,9 +95,7 @@ class PentairFieldSwitch(PentairEntity, SwitchEntity):
         await self._write(self.entity_description.off_value)
 
     async def _write(self, value: str) -> None:
-        await self.coordinator.async_set_fields(
-            {self.entity_description.field: value}
-        )
+        await self.coordinator.async_set_fields({self.entity_description.field: value})
         # Optimistic state — refresh confirms.  Update_interval is 30s, so
         # explicitly requesting a refresh keeps the UI snappy.
         await self.coordinator.async_request_refresh()

--- a/custom_components/pentair_cloud/switch.py
+++ b/custom_components/pentair_cloud/switch.py
@@ -1,0 +1,103 @@
+"""Pentair switch platform.
+
+Currently scoped to Color Sync (`deviceType == "PLC1"`), where field `d13`
+is a U8 on/off flag (`"0"` / `"1"`).  Adding more switchable devices is a
+matter of expanding `_SUPPORTED_DEVICE_TYPES` and the matching descriptions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from homeassistant.components.switch import (
+    SwitchEntity,
+    SwitchEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import PentairConfigEntry
+from .entity import PentairEntity
+from .helpers import get_field_value
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class PentairSwitchEntityDescription(SwitchEntityDescription):
+    """Entity description with the field key + value mapping."""
+
+    field: str
+    on_value: str = "1"
+    off_value: str = "0"
+    is_on_fn: Callable[[Any], bool] | None = None
+
+
+_COLOR_SYNC_SWITCH = PentairSwitchEntityDescription(
+    key="d13",
+    field="d13",
+    translation_key="pool_lights",
+    icon="mdi:pool",
+)
+
+# Map deviceType -> list of switch descriptions to instantiate.
+_SUPPORTED_DEVICE_TYPES: dict[str, list[PentairSwitchEntityDescription]] = {
+    "PLC1": [_COLOR_SYNC_SWITCH],
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: PentairConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pentair switch entities for supported device types."""
+    coordinator = config_entry.runtime_data
+    entities: list[PentairFieldSwitch] = []
+    for device_coordinator in coordinator.device_coordinators:
+        data = device_coordinator.get_device_data()
+        if not data:
+            continue
+        for description in _SUPPORTED_DEVICE_TYPES.get(data.get("deviceType"), []):
+            entities.append(
+                PentairFieldSwitch(
+                    coordinator=device_coordinator,
+                    config_entry=config_entry,
+                    description=description,
+                    device_id=data["deviceId"],
+                )
+            )
+    if entities:
+        async_add_entities(entities)
+
+
+class PentairFieldSwitch(PentairEntity, SwitchEntity):
+    """Switch backed by a single string-valued Pentair field."""
+
+    entity_description: PentairSwitchEntityDescription
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the device is on (field == on_value)."""
+        if (data := self.get_device()) is None:
+            return None
+        return get_field_value(self.entity_description.field, data) == (
+            self.entity_description.on_value
+        )
+
+    async def async_turn_on(self, **_: Any) -> None:
+        await self._write(self.entity_description.on_value)
+
+    async def async_turn_off(self, **_: Any) -> None:
+        await self._write(self.entity_description.off_value)
+
+    async def _write(self, value: str) -> None:
+        await self.coordinator.async_set_fields(
+            {self.entity_description.field: value}
+        )
+        # Optimistic state — refresh confirms.  Update_interval is 30s, so
+        # explicitly requesting a refresh keeps the UI snappy.
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary

Adds **switch / select / button** platforms scoped to Pentair Color Sync controllers (`deviceType: PLC1` — driving MicroBrite RGB pool lights, e.g. part 618031), so the integration can actually drive the lights instead of just reporting their state.

| Entity | Type | What it does | Field |
|---|---|---|---|
| Pool lights | `switch` | On / off | `d13` |
| Pool lights mode | `select` | One of 12 scenes (5 solid colors + 7 shows) | `d1` (0..4, 7..13) |
| Pool lights hold | `button` | Freeze current animation on present color | `d1` = 5 |
| Pool lights recall | `button` | Resume last show after Hold | `d1` = 6 |

## How the writes work

Color Sync is a cloud-only product — there's no LAN API, only an outbound MQTT-over-TLS session to AWS IoT.  The Pentair Home iOS/Android app drives it via SigV4-signed REST `PUT` against `device/device-service/user/device/{id}`, body `{"payload": {"<field>": "<value>"}}`.

pypentair 0.4.1 already maintains the AWS Cognito tokens + provides a `SigV4Auth` instance via `client.get_auth()` for the GET path; this PR reuses that same client to issue PUTs.  Pattern mirrors @thk-socal's IntelliFlo 3 pump-program work in `hacs-pentair-switch`.

On the device coordinator:

```python
PentairDeviceDataUpdateCoordinator.async_set_fields(fields: dict[str, str]) -> dict
```

Validates that Pentair acknowledges with `code == "set_device_success"` and raises otherwise.

## d1 enum mapping

| d1 | Display name | Kind |
|---|---|---|
| 0 | Red | solid |
| 1 | White | solid |
| 2 | Magenta | solid |
| 3 | Green | solid |
| 4 | Blue | solid |
| 5 | Hold | command (exposed as button) |
| 6 | Recall | command (exposed as button) |
| 7 | SAm | show |
| 8 | Party | show |
| 9 | Romance | show |
| 10 | Caribbean | show |
| 11 | American | show |
| 12 | Sunset | show |
| 13 | Royal | show |

Empirically mapped 2026-05-18 against a live PLC1 (fwVersion 1.0) by setting each value and reading the canonical name back from the Pentair Home iOS app.  Field metadata claims `max=14`, but the device silently clamps 14→13, so the select intentionally stops at Royal.

## Reliability

Added after initial review (commit `f4a9307`).  Long-uptime stress-test of the bridge that prototyped this PR revealed a token-refresh failure mode: after ~1 hour, pypentair's underlying `pycognito.check_token()` does not detect that the id_token has expired, and every subsequent Pentair call returns `403 — The security token included in the request is expired`.  The integration would surface this as recurring `UpdateFailed` from both coordinators and `RuntimeError` from writes.

Fix is two-layered, no API behavior change:

- **Proactive** — `_ensure_token_fresh(client)` decodes the cached id_token JWT, reads `exp`, and calls `renew_access_token()` when fewer than 5 minutes remain.  Invoked at the top of every blocking I/O helper.
- **Reactive** — `_signed_put_sync`, `_get_devices_with_refresh`, and `_get_device_with_refresh` catch 401/403, call `renew_access_token()`, and retry once.  Covers mid-call expiry / server-side revoke.

Refresh failures (e.g. refresh_token revoked beyond its 30-day window) still propagate so the integration can mark itself unhealthy normally.

## Test plan

- [x] All five existing platforms still load cleanly with `PLATFORMS` extended.
- [x] Live PLC1: writing `d13` → `"0"` returns `set_device_success` and the lights physically turn off.
- [x] Live PLC1: writing `d1` → each of 0..13 returns `set_device_success` and the app/device reflects the new mode.
- [x] Coordinator refresh after a write surfaces the new state within `UPDATE_INTERVAL`.
- [ ] Maintainer test on a different Pentair account / device fleet to confirm no regressions for IntelliFlo / IntelliCenter / etc.

## Design notes / decisions

- **PLC1 scoping** — added new platforms with `_SUPPORTED_DEVICE_TYPES` lookup tables so adding more device families later is just describing the right fields.  Devices that aren't in the table produce no new entities (sensor + binary_sensor unchanged).
- **Hold / Recall as buttons not select options** — they're write-only commands, not steady states.  `d1` snapshots back to whatever show is active rather than to 5/6.  Modeling them as items in the select would lie about state.
- **No new requirements** — `botocore` + `requests` were already transitively pulled in by `pypentair`.
- **Translation keys** added in `strings.json` so HA picks up canonical names rather than auto-generating from the field codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Color Sync (PLC1) pool light controls: on/off switch, mode selector, and hold/recall command buttons.
  * Expanded the integration to expose additional Home Assistant platforms for these controls.
* **Bug Fixes / Improvements**
  * Improved write-command reliability with proactive authentication refresh and a retry on auth failures.
* **Documentation**
  * README updated with supported devices, exposed entity types, and current telemetry/control behavior.
* **Localization**
  * Added user-facing names for the new switch, select, and button entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
