### PR TITLE
fix: unwrap wrapped field values before conversion

### DIFF
--- a/custom_components/pentair_cloud/helpers.py
+++ b/custom_components/pentair_cloud/helpers.py
@@ -21,7 +21,12 @@ def convert_timestamp(_ts: float) -> datetime:
 
 def get_field_value(key: str, data: dict) -> Any:
     """Get field value."""
-    name, value = get_api_field_name_and_value(key, data["fields"].get(key))
+    raw = data["fields"].get(key)
+    # Some fields arrive wrapped as {"value": ..., ...}. Unwrap before conversion,
+    # since the per-key conversion functions expect the scalar.
+    if isinstance(raw, dict) and "value" in raw:
+        raw = raw["value"]
+    name, value = get_api_field_name_and_value(key, raw)
     if key not in data["fields"]:
         _LOGGER.warning('%s key "%s" is missing in fields data', name, key)
     return value.get("value", value) if isinstance(value, dict) else value


### PR DESCRIPTION
Every entry in the `fields` payload now arrives as a metadata dict with the reading under `"value"`, so `get_api_field_name_and_value` is handed the dict instead of the scalar. The per-key conversion function raises, `pypentair` logs `Could not convert key`, and the unconverted raw value falls through.

All 293 fields on my pump are wrapped. One of them:

```
's19' = {'name': 'Current Motor Speed', 'min': '0', 'max': '4000',
         'unit': 'tenths %', 'type': 'U16', 'category': 'status',
         'value': '875', 'timestamp': '1786212708', ...}
```

`API_FIELD_VALUE_FUNCTION` maps `s19` to the divide-by-ten helper. It wants `'875'` and gets the whole dict. What that costs on my system: current motor speed and current estimated flow are published in tenths and read ten times high, RSSI stays a string instead of an int, and device time never becomes a datetime.

Unwrapping before the call restores all of it. I left the existing dict check on the return value alone, so an unwrapped payload behaves exactly as it does today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of field values returned in wrapped dictionary formats.
  * Preserved existing conversion behavior and warnings for missing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->